### PR TITLE
Fixed error where elementType flags was not being saved.

### DIFF
--- a/cacheflag/controllers/CacheFlagController.php
+++ b/cacheflag/controllers/CacheFlagController.php
@@ -74,7 +74,7 @@ class CacheFlagController extends BaseController
             $target = @$flag['target'] ?: null;
             $pointId = @$flag['pointId'] ?: null;
 
-            if (!$target || !$pointId) {
+            if (!$target) {
                 continue;
             }
 
@@ -185,6 +185,7 @@ class CacheFlagController extends BaseController
             "My, what beautiful flags you have.",
             "Your flags are safe with me.",
             "I'll just hang on to these flags for you.",
+            "If you want a symbolic gesture, don't burn the flag; save it.",
         );
         return $messages[array_rand($messages)];
     }

--- a/cacheflag/templates/index.twig
+++ b/cacheflag/templates/index.twig
@@ -49,7 +49,7 @@
                                         <td scope="col" class="cacheFlag-flagsInput">
 
                                             {% set flagKey = point['id'] is defined ? point.id : point.classHandle %}
-                                            {% set flagInputId = target ~ (point['id'] is defined ? point.id : '') %}
+                                            {% set flagInputId = target ~ (point['id'] is defined ? point.id : point.classHandle) %}
                                             {% set flag = cacheFlags[target][flagKey] is defined ? cacheFlags[target][flagKey] : false %}
 
                                             <input type="text" data-id="{{ flagInputId }}" class="cacheFlag-inputText cacheFlag-inputFlags text nicetext" placeholder="" name="cacheflags[{{ flagInputId }}][flags]" size="25" value="{{ flag ? flag.flags }}" />


### PR DESCRIPTION
Element type flags were not being saved due to an incorrect input id in the flags input form. Also removed $pointId as a required parameter in CacheFlagController, since element types don't have an id.
