### PR TITLE
Fix PHP error 'Undefined variable: cacheKey1' in Live Preview or when…

### DIFF
--- a/cacheflag/twigextensions/CacheFlag_Node.php
+++ b/cacheflag/twigextensions/CacheFlag_Node.php
@@ -106,10 +106,7 @@ class CacheFlag_Node extends \Twig_Node
         }
 
         $compiler
-            ->raw(", \$cacheBody{$n});\n")
-            ->outdent()
-            ->write("}\n")
-            ->outdent();
+            ->raw(", \$cacheBody{$n});\n");
 
         if ($flags) {
             $compiler->write("\$cacheFlagService->addCacheByKey(\$cacheKey{$n}, ");
@@ -118,6 +115,9 @@ class CacheFlag_Node extends \Twig_Node
         }
 
         $compiler
+            ->outdent()
+            ->write("}\n")
+            ->outdent()
             ->write("}\n")
             ->write("echo \$cacheBody{$n};\n");
 


### PR DESCRIPTION
… viewing an unpublished entry.

The fix consists of moving `cacheFlagService->addCacheByKey($cacheKey{$n}, ...` 
inside the condition `if (!$ignoreCacheFlag{$n}) {...`. Because `$cacheKey{$n}`  variable is only defined when this condition is met.